### PR TITLE
Support 'delta' snapshots with new --include and --remove flags

### DIFF
--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -235,7 +235,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 
 		matchedInsensitive, childMayMatchInsensitive, err := filter.ListWithChild(insensitiveIncludePatterns, strings.ToLower(item))
 		if err != nil {
-			msg.E("error for iexclude pattern: %v", err)
+			msg.E("error for iinclude pattern: %v", err)
 		}
 
 		selectedForRestore = matched || matchedInsensitive

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -227,7 +227,7 @@ func TestArchiverSave(t *testing.T) {
 			}
 			arch.runWorkers(ctx, wg)
 
-			node, excluded, err := arch.Save(ctx, "/", filepath.Join(tempdir, "file"), nil)
+			node, excluded, err := arch.Save(ctx, "/", filepath.Join(tempdir, "file"), nil, SnapshotOptions{Time: time.Now()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -304,7 +304,7 @@ func TestArchiverSaveReaderFS(t *testing.T) {
 			}
 			arch.runWorkers(ctx, wg)
 
-			node, excluded, err := arch.Save(ctx, "/", filename, nil)
+			node, excluded, err := arch.Save(ctx, "/", filename, nil, SnapshotOptions{Time: time.Now()})
 			t.Logf("Save returned %v %v", node, err)
 			if err != nil {
 				t.Fatal(err)
@@ -845,7 +845,7 @@ func TestArchiverSaveDir(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ft, err := arch.SaveDir(ctx, "/", test.target, fi, nil, nil)
+			ft, err := arch.SaveDir(ctx, "/", test.target, fi, nil, nil, SnapshotOptions{Time: time.Now()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -918,7 +918,7 @@ func TestArchiverSaveDirIncremental(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ft, err := arch.SaveDir(ctx, "/", tempdir, fi, nil, nil)
+		ft, err := arch.SaveDir(ctx, "/", tempdir, fi, nil, nil, SnapshotOptions{Time: time.Now()})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1107,7 +1107,7 @@ func TestArchiverSaveTree(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			fn, _, err := arch.SaveTree(ctx, "/", atree, nil, nil)
+			fn, _, err := arch.SaveTree(ctx, "/", atree, nil, nil, SnapshotOptions{Time: time.Now()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2236,7 +2236,7 @@ func TestRacyFileSwap(t *testing.T) {
 	arch.runWorkers(ctx, wg)
 
 	// fs.Track will panic if the file was not closed
-	_, excluded, err := arch.Save(ctx, "/", tempfile, nil)
+	_, excluded, err := arch.Save(ctx, "/", tempfile, nil, SnapshotOptions{Time: time.Now()})
 	if err == nil {
 		t.Errorf("Save() should have failed")
 	}

--- a/internal/archiver/scanner_test.go
+++ b/internal/archiver/scanner_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/restic/restic/internal/fs"
@@ -112,7 +113,7 @@ func TestScanner(t *testing.T) {
 				results[p] = s
 			}
 
-			err = sc.Scan(ctx, []string{"."})
+			err = sc.Scan(ctx, []string{"."}, SnapshotOptions{Time: time.Now()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -263,7 +264,7 @@ func TestScannerError(t *testing.T) {
 				}
 			}
 
-			err = sc.Scan(ctx, []string{"."})
+			err = sc.Scan(ctx, []string{"."}, SnapshotOptions{Time: time.Now()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -310,7 +311,7 @@ func TestScannerCancel(t *testing.T) {
 		}
 	}
 
-	err = sc.Scan(ctx, []string{"."})
+	err = sc.Scan(ctx, []string{"."}, SnapshotOptions{Time: time.Now()})
 	if err != nil {
 		t.Errorf("unexpected error %v found", err)
 	}

--- a/internal/fs/helpers.go
+++ b/internal/fs/helpers.go
@@ -1,6 +1,9 @@
 package fs
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 // IsRegularFile returns true if fi belongs to a normal file. If fi is nil,
 // false is returned.
@@ -10,4 +13,28 @@ func IsRegularFile(fi os.FileInfo) bool {
 	}
 
 	return fi.Mode()&os.ModeType == 0
+}
+
+func IsPathIncluded(includes []string, path string) bool {
+	var result bool = len(includes) == 0
+	if !result {
+		for _, x := range includes {
+			if strings.Contains(x, path) || strings.Contains(path, x) {
+				result = true
+				break
+			}
+		}
+	}
+	return result
+}
+
+func IsPathRemoved(removes []string, path string) bool {
+	if len(removes) != 0 {
+		for _, x := range removes {
+			if strings.Contains(path, x) {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Add new flags --include and --remove for backup command to support delta backups. --include is used when specific backup paths need to be scanned without scanning the whole backup set. --remove is used for removing backed up paths from the backup set. This is useful in combination with file watchers watching for changes to files/folders and calling restic with a batch of changes to create a new snapshot without having to go through the entire tree of the backup set.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [ ] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [ ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
